### PR TITLE
Allow image uploads in any channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - Uploaded images are saved to `cdn/ImageUploads/` using the naming pattern `<user_id>-<message_id>_<nn><extension>` where `nn` increments for multiple attachments. The feature reads environment variables `IMAGE_UPVOTE_EMOJI_NAME` and `IMAGE_UPVOTE_THRESHOLD`.
 - After a successful upload the bot reacts with `:white_check_mark:` to mark processed messages and counts emoji reactions each time to ensure accuracy after restarts.
 - Image uploads are logged through the `AdminLog` cog with their filename, size in megabytes, a link to the source message, and whether they were saved via upvotes or forced.
+- The link uses the message's `jump_url` so logs open directly to the original message.
 
 This repository powers a Discord bot built around modular extensions and utilities. This file summarizes the layout and guidelines for AI contributors.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@
 - Update this file with any new project knowledge.
 
 ## Notes
-- `image_upvote` extension allows images in channel `1003337674008055919` to be uploaded once they receive five `:arrow_upvote:` reactions. Admins can force the upload via a message context menu.
-- Uploaded images are saved to `cdn/ImageUploads/` using the naming pattern `<user_id>-<message_id>_<nn><extension>` where `nn` increments for multiple attachments. The feature reads environment variables `IMAGE_UPVOTE_CHANNEL_ID`, `IMAGE_UPVOTE_EMOJI_NAME`, and `IMAGE_UPVOTE_THRESHOLD` (defaults match previous hardcoded values).
+- `image_upvote` extension allows images posted anywhere in a guild to be uploaded once they receive five `:arrow_upvote:` reactions. Admins can force the upload via a message context menu available in all channels.
+- Uploaded images are saved to `cdn/ImageUploads/` using the naming pattern `<user_id>-<message_id>_<nn><extension>` where `nn` increments for multiple attachments. The feature reads environment variables `IMAGE_UPVOTE_EMOJI_NAME` and `IMAGE_UPVOTE_THRESHOLD`.
 - After a successful upload the bot reacts with `:white_check_mark:` to mark processed messages and counts emoji reactions each time to ensure accuracy after restarts.
-- Image uploads are logged through the `AdminLog` cog with their filename, size in megabytes, and whether they were saved via upvotes or forced.
+- Image uploads are logged through the `AdminLog` cog with their filename, size in megabytes, a link to the source message, and whether they were saved via upvotes or forced.
 
 This repository powers a Discord bot built around modular extensions and utilities. This file summarizes the layout and guidelines for AI contributors.
 

--- a/extensions/image_upvote.py
+++ b/extensions/image_upvote.py
@@ -53,14 +53,22 @@ class ImageUpvote(commands.Cog):
                     if source == "force"
                     else "Image uploaded via upvotes"
                 )
+                if source == "force" and interaction:
+                    event_status = (
+                        f"{file_path.name} - {size_mb:.2f} MB\n"
+                        f"Force by {interaction.user.mention} in {message.channel.mention}\n"
+                        f"{message.jump_url}"
+                    )
+                else:
+                    event_status = (
+                        f"{file_path.name} - {size_mb:.2f} MB\n"
+                        f"{message.jump_url}"
+                    )
                 await admin_log_cog.log_event(
                     message.guild.id,
                     priority="info",
                     event_name=event,
-                    event_status=(
-                        f"{file_path.name} - {size_mb:.2f} MB\n"
-                        f"[Message Link]({message.jump_url})"
-                    ),
+                    event_status=event_status,
                 )
         self._uploaded_messages.add(message.id)
         await message.add_reaction("✅")
@@ -105,7 +113,9 @@ class ImageUpvote(commands.Cog):
 @app_commands.allowed_installs(guilds=True, users=False)
 @app_commands.guild_only()
 async def force_upload(interaction: discord.Interaction, message: discord.Message) -> None:
-    logger.info(f"Force upload triggered by {interaction.user} for message {message.id}")
+    logger.info(
+        f"Force upload triggered by {interaction.user} in {message.channel} ({message.jump_url})"
+    )
     if not interaction.user.guild_permissions.manage_messages:
         await interaction.response.send_message("You do not have permission to use this.", ephemeral=True)
         return

--- a/extensions/image_upvote.py
+++ b/extensions/image_upvote.py
@@ -6,7 +6,6 @@ from logger import LoggerManager
 import os
 from pathlib import Path
 
-CHANNEL_ID = int(os.getenv("IMAGE_UPVOTE_CHANNEL_ID", "1003337674008055919"))
 UPVOTE_EMOJI_NAME = os.getenv("IMAGE_UPVOTE_EMOJI_NAME", "arrow_upvote")
 UPVOTE_THRESHOLD = int(os.getenv("IMAGE_UPVOTE_THRESHOLD", "4"))
 UPLOAD_DIR = Path("cdn/ImageUploads")
@@ -58,15 +57,16 @@ class ImageUpvote(commands.Cog):
                     message.guild.id,
                     priority="info",
                     event_name=event,
-                    event_status=f"{file_path.name} - {size_mb:.2f} MB",
+                    event_status=(
+                        f"{file_path.name} - {size_mb:.2f} MB\n"
+                        f"[Message Link]({message.jump_url})"
+                    ),
                 )
         self._uploaded_messages.add(message.id)
         await message.add_reaction("✅")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
-        if payload.channel_id != CHANNEL_ID:
-            return
         if payload.emoji.name != UPVOTE_EMOJI_NAME:
             return
         channel = self.bot.get_channel(payload.channel_id)
@@ -108,10 +108,6 @@ async def force_upload(interaction: discord.Interaction, message: discord.Messag
     logger.info(f"Force upload triggered by {interaction.user} for message {message.id}")
     if not interaction.user.guild_permissions.manage_messages:
         await interaction.response.send_message("You do not have permission to use this.", ephemeral=True)
-        return
-    if message.channel.id != CHANNEL_ID:
-        await interaction.response.send_message("This command can only be used in the configured channel.",
-                                                ephemeral=True)
         return
     if not any(att.content_type and att.content_type.startswith("image") for att in message.attachments):
         await interaction.response.send_message("The selected message does not contain an image.", ephemeral=True)


### PR DESCRIPTION
## Summary
- allow image upvote listener and Force Upload context menu in any server channel
- log uploaded images with a link to the source message
- document logging changes in AGENTS instructions

## Testing
- `python -m py_compile extensions/image_upvote.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b479cac8329ad992786743ab8d0