### PR TITLE
Preserve GIFs in image_upvote and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - After a successful upload the bot reacts with `:white_check_mark:` to mark processed messages and counts emoji reactions each time to ensure accuracy after restarts.
 - Image uploads are logged through the `AdminLog` cog with their filename, size in megabytes, a link to the source message, and whether they were saved via upvotes or forced.
 - The link uses the message's `jump_url` so logs open directly to the original message.
-- Uploaded images are converted to WEBP and videos to MP4. Unsupported formats are skipped, the bot reacts with `:negative_squared_cross_mark:`, and the failure reason is logged. Each successful upload logs the full CDN URL (`https://cdn.killua.de/ImageUploads/<filename>`).
+- Uploaded images are converted to WEBP unless they are GIF or already WEBP; those formats are saved without conversion. Videos are converted to MP4. Unsupported formats are skipped, the bot reacts with `:negative_squared_cross_mark:`, and the failure reason is logged. Each successful upload logs the full CDN URL (`https://cdn.killua.de/ImageUploads/<filename>`).
 
 This repository powers a Discord bot built around modular extensions and utilities. This file summarizes the layout and guidelines for AI contributors.
 

--- a/extensions/image_upvote.py
+++ b/extensions/image_upvote.py
@@ -49,17 +49,22 @@ class ImageUpvote(commands.Cog):
         for idx, attachment in enumerate(attachments, start=1):
             data = await attachment.read()
             extension = Path(attachment.filename).suffix
+            file_stem = f"{message.author.id}-{message.id}_{idx:02d}"
             try:
                 if attachment.content_type.startswith("image"):
-                    file_path = UPLOAD_DIR / (
-                        f"{message.author.id}-{message.id}_{idx:02d}.webp"
-                    )
                     with Image.open(io.BytesIO(data)) as img:
-                        img.save(file_path, "WEBP")
+                        img_format = img.format
+                        if img_format == "GIF":
+                            file_path = UPLOAD_DIR / f"{file_stem}.gif"
+                            file_path.write_bytes(data)
+                        elif img_format == "WEBP":
+                            file_path = UPLOAD_DIR / f"{file_stem}.webp"
+                            file_path.write_bytes(data)
+                        else:
+                            file_path = UPLOAD_DIR / f"{file_stem}.webp"
+                            img.save(file_path, "WEBP")
                 elif attachment.content_type.startswith("video"):
-                    file_path = UPLOAD_DIR / (
-                        f"{message.author.id}-{message.id}_{idx:02d}.mp4"
-                    )
+                    file_path = UPLOAD_DIR / f"{file_stem}.mp4"
                     with tempfile.NamedTemporaryFile(
                         delete=False, suffix=extension
                     ) as temp_file:


### PR DESCRIPTION
## Summary
- prevent image_upvote from converting GIFs and already-webp files
- note new image handling behavior in AGENTS guidelines

## Testing
- `python -m py_compile extensions/image_upvote.py`


------
https://chatgpt.com/codex/tasks/task_e_68b02318c5fc83298b5a149816ebcc1c