### PR TITLE
Handle failed uploads and declare Pillow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ google-api-python-client>=2.179.0
 uvicorn>=0.35.0
 fastapi>=0.116.1
 pydantic>=2.11.7
-pillow~=11.3.0
+Pillow>=11.3.0


### PR DESCRIPTION
## Summary
- only mark messages as processed when at least one attachment saves successfully
- surface failed force uploads and add Pillow requirement for image conversions

## Testing
- `python -m py_compile extensions/image_upvote.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0375c33a88329afae0ece352da142