### PR TITLE
React to failed uploads with negative cross mark

### DIFF
--- a/extensions/image_upvote.py
+++ b/extensions/image_upvote.py
@@ -170,6 +170,8 @@ class ImageUpvote(commands.Cog):
             rebuild_links_index()
             self._uploaded_messages.add(message.id)
             await message.add_reaction("✅")
+        else:
+            await message.add_reaction("❎")
         return any_success
 
     @commands.Cog.listener()


### PR DESCRIPTION
## Summary
- React to messages with ❎ when all attachments fail to save

## Testing
- `python -m py_compile extensions/image_upvote.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03961fc0c8329a757d9e55d6df2f1