### PR TITLE
React to failed uploads with negative cross mark

### DIFF
--- a/extensions/image_upvote.py
+++ b/extensions/image_upvote.py
@@ -171,7 +171,14 @@ class ImageUpvote(commands.Cog):
             self._uploaded_messages.add(message.id)
             await message.add_reaction("✅")
         else:
-            await message.add_reaction("❎")
+            if not any(
+                    str(reaction.emoji) == "❎" and reaction.me
+                    for reaction in message.reactions
+            ):
+                try:
+                    await message.add_reaction("❎")
+                except discord.HTTPException:
+                    pass
         return any_success
 
     @commands.Cog.listener()


### PR DESCRIPTION
## Summary
- React to messages with ❎ when all attachments fail to save
- Skip adding a failure reaction if it already exists to avoid API errors

## Testing
- `python -m py_compile extensions/image_upvote.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03b625924832997e12514850e0a2a